### PR TITLE
  refactor(sensors): move speed estimation to SensorManager

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -98,8 +98,8 @@ dependencies = [
  "esp-idf-svc",
  "esp-idf-sys",
  "log",
- "motorsport-telemetry",
  "neo6m",
+ "sensor-fusion",
  "serde",
  "serde_json",
  "smart-leds",
@@ -937,18 +937,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
-name = "motorsport-telemetry"
-version = "0.1.0"
-dependencies = [
- "esp-idf-hal",
- "esp-idf-svc",
- "esp-idf-sys",
- "log",
- "serde",
- "serde_json",
-]
-
-[[package]]
 name = "nb"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1240,6 +1228,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56e6fa9c48d24d85fb3de5ad847117517440f6beceb7798af16b4a87d616b8d0"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "sensor-fusion"
+version = "0.1.0"
+dependencies = [
+ "esp-idf-hal",
+ "esp-idf-svc",
+ "esp-idf-sys",
+ "log",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]

--- a/framework/Cargo.toml
+++ b/framework/Cargo.toml
@@ -1,16 +1,16 @@
 [package]
-name = "motorsport-telemetry"
+name = "sensor-fusion"
 version.workspace = true
 authors.workspace = true
 edition.workspace = true
-description = "Open-source framework for building custom automotive sensor fusion systems"
-keywords = ["telemetry", "sensor-fusion", "kalman-filter", "automotive", "motorsport"]
+description = "Sensor fusion and state estimation library for embedded systems"
+keywords = ["sensor-fusion", "kalman-filter", "ekf", "state-estimation", "embedded"]
 categories = ["embedded", "no-std", "science"]
 license = "MIT"
 repository = "https://github.com/jctoledo/blackbox"
 
 [lib]
-name = "motorsport_telemetry"
+name = "sensor_fusion"
 
 [dependencies]
 # Use workspace dependencies

--- a/framework/README.md
+++ b/framework/README.md
@@ -1,6 +1,6 @@
-# Motorsport Telemetry Framework
+# Sensor Fusion Framework
 
-A modular, extensible Rust framework for building custom automotive sensor fusion systems. Build professional-grade telemetry for track days, racing, vehicle dynamics research, and fleet monitoring without vendor lock-in.
+A modular, extensible Rust framework for building custom sensor fusion systems. Build professional-grade telemetry for track days, racing, vehicle dynamics research, and fleet monitoring without vendor lock-in.
 
 ## Features
 
@@ -25,9 +25,9 @@ You focus on your specific sensors and application - the framework handles the f
 ## Example Usage
 
 ```rust
-use motorsport_telemetry::sensor_framework::{SensorRegistry, Sensor};
-use motorsport_telemetry::ekf::Ekf;
-use motorsport_telemetry::transforms::{body_to_earth, remove_gravity};
+use sensor_fusion::sensor_framework::{SensorRegistry, Sensor};
+use sensor_fusion::ekf::Ekf;
+use sensor_fusion::transforms::{body_to_earth, remove_gravity};
 
 // Create sensor registry
 let mut registry = SensorRegistry::new();
@@ -147,13 +147,15 @@ Basic sensor trait definitions (IMU, GPS, generic sensors).
                │ uses
                ▼
 ┌─────────────────────────────────────────┐
-│  Motorsport Telemetry Framework         │
+│  Sensor Fusion Framework                │
 │  ┌─────────────────────────────────┐    │
 │  │ sensor_framework (Plugin API)   │    │
 │  ├─────────────────────────────────┤    │
 │  │ ekf (Sensor Fusion)             │    │
 │  ├─────────────────────────────────┤    │
 │  │ transforms (Coordinate Math)    │    │
+│  ├─────────────────────────────────┤    │
+│  │ velocity (Speed Estimation)     │    │
 │  └─────────────────────────────────┘    │
 └─────────────────────────────────────────┘
 ```
@@ -173,10 +175,10 @@ Add to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-motorsport-telemetry = { path = "../path/to/framework" }
+sensor-fusion = { path = "../path/to/framework" }
 
 # Or from crates.io (when published):
-# motorsport-telemetry = "0.1"
+# sensor-fusion = "0.1"
 ```
 
 ## Features
@@ -185,7 +187,7 @@ The framework supports optional features:
 
 ```toml
 [dependencies]
-motorsport-telemetry = { version = "0.1", features = ["esp32", "mqtt"] }
+sensor-fusion = { version = "0.1", features = ["esp32", "mqtt"] }
 ```
 
 - `esp32` - ESP32-specific HAL support
@@ -231,7 +233,7 @@ MIT License - Use it, modify it, sell it, race with it. See `LICENSE` for detail
 
 ## Documentation
 
-- [API Documentation](https://docs.rs/motorsport-telemetry) (when published)
+- [API Documentation](https://docs.rs/sensor-fusion) (when published)
 - [Sensor Toolkit Guide](../docs/SENSOR_TOOLKIT_GUIDE.md)
 - [Architecture Guide](../docs/ARCHITECTURE.md)
 - [Workspace Structure](../WORKSPACE_STRUCTURE.md)

--- a/framework/src/lib.rs
+++ b/framework/src/lib.rs
@@ -52,7 +52,7 @@
 //! ## Example Usage
 //!
 //! ```rust,no_run
-//! use motorsport_telemetry::{
+//! use sensor_fusion::{
 //!     ekf::Ekf,
 //!     sensor_framework::{GpsReading, ImuReading, Sensor, SensorDataType, SensorRegistry},
 //! };
@@ -89,7 +89,7 @@
 //! The framework is **open for extension** without modification:
 //!
 //! ```rust,no_run
-//! use motorsport_telemetry::sensor_framework::{SensorDataType, SensorReading};
+//! use sensor_fusion::sensor_framework::{SensorDataType, SensorReading};
 //!
 //! #[derive(Debug)]
 //! struct RadarReading {
@@ -135,6 +135,7 @@ pub mod ekf;
 pub mod sensor_framework;
 pub mod sensors;
 pub mod transforms;
+pub mod velocity;
 
 // Re-export commonly used types from sensor_framework
 // Re-export EKF

--- a/framework/src/velocity.rs
+++ b/framework/src/velocity.rs
@@ -1,0 +1,146 @@
+//! Velocity estimation and source selection
+//!
+//! This module provides pure functions for selecting the best velocity
+//! estimate from multiple sources (EKF, GPS, etc.).
+
+/// Velocity selection threshold (m/s)
+/// Below this, EKF velocity is considered unreliable and GPS is preferred
+pub const VELOCITY_THRESHOLD: f32 = 0.1;
+
+/// Select best velocity from available sources
+///
+/// Returns a consistent (vx, vy, speed) tuple from a single source:
+/// - Prefers EKF velocity when magnitude exceeds threshold
+/// - Falls back to GPS velocity if EKF is unavailable or below threshold
+/// - Returns zeros if no valid source
+///
+/// # Arguments
+/// * `ekf_velocity` - Velocity from EKF as (vx, vy), or None
+/// * `gps_velocity` - Velocity from GPS as (vx, vy), or None
+///
+/// # Returns
+/// * `(vx, vy, speed)` - Consistent velocity tuple from same source
+///
+/// # Example
+/// ```
+/// use sensor_fusion::velocity::select_best_velocity;
+///
+/// // EKF velocity above threshold - uses EKF
+/// let (vx, vy, speed) = select_best_velocity(Some((3.0, 4.0)), Some((1.0, 0.0)));
+/// assert_eq!((vx, vy), (3.0, 4.0));
+/// assert!((speed - 5.0).abs() < 0.001);
+///
+/// // EKF velocity below threshold - falls back to GPS
+/// let (vx, vy, speed) = select_best_velocity(Some((0.05, 0.05)), Some((1.0, 0.0)));
+/// assert_eq!((vx, vy), (1.0, 0.0));
+/// ```
+pub fn select_best_velocity(
+    ekf_velocity: Option<(f32, f32)>,
+    gps_velocity: Option<(f32, f32)>,
+) -> (f32, f32, f32) {
+    // Try EKF first
+    if let Some((vx, vy)) = ekf_velocity {
+        let speed = (vx * vx + vy * vy).sqrt();
+        if speed > VELOCITY_THRESHOLD {
+            return (vx, vy, speed);
+        }
+    }
+    // Fallback to GPS
+    if let Some((vx, vy)) = gps_velocity {
+        let speed = (vx * vx + vy * vy).sqrt();
+        return (vx, vy, speed);
+    }
+    // No valid source
+    (0.0, 0.0, 0.0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_prefers_ekf_above_threshold() {
+        // EKF velocity (3, 4) has magnitude 5.0, well above 0.1 threshold
+        let ekf = Some((3.0, 4.0));
+        let gps = Some((1.0, 0.0));
+
+        let (vx, vy, speed) = select_best_velocity(ekf, gps);
+
+        assert_eq!((vx, vy), (3.0, 4.0));
+        assert!((speed - 5.0).abs() < 0.001);
+    }
+
+    #[test]
+    fn test_falls_back_to_gps_below_threshold() {
+        // EKF velocity (0.05, 0.05) has magnitude ~0.07, below 0.1 threshold
+        let ekf = Some((0.05, 0.05));
+        let gps = Some((1.0, 0.0));
+
+        let (vx, vy, speed) = select_best_velocity(ekf, gps);
+
+        assert_eq!((vx, vy), (1.0, 0.0));
+        assert!((speed - 1.0).abs() < 0.001);
+    }
+
+    #[test]
+    fn test_uses_gps_when_no_ekf() {
+        let gps = Some((2.0, 0.0));
+
+        let (vx, vy, speed) = select_best_velocity(None, gps);
+
+        assert_eq!((vx, vy), (2.0, 0.0));
+        assert!((speed - 2.0).abs() < 0.001);
+    }
+
+    #[test]
+    fn test_returns_zeros_when_no_source() {
+        let (vx, vy, speed) = select_best_velocity(None, None);
+
+        assert_eq!((vx, vy, speed), (0.0, 0.0, 0.0));
+    }
+
+    #[test]
+    fn test_returns_zeros_when_ekf_below_threshold_no_gps() {
+        // EKF below threshold, no GPS fallback
+        let ekf = Some((0.01, 0.01));
+
+        let (vx, vy, speed) = select_best_velocity(ekf, None);
+
+        assert_eq!((vx, vy, speed), (0.0, 0.0, 0.0));
+    }
+
+    #[test]
+    fn test_components_consistent_with_speed() {
+        // Verify that returned speed matches sqrt(vx² + vy²)
+        let ekf = Some((3.0, 4.0));
+
+        let (vx, vy, speed) = select_best_velocity(ekf, None);
+        let computed_speed = (vx * vx + vy * vy).sqrt();
+
+        assert!((speed - computed_speed).abs() < 0.001);
+    }
+
+    #[test]
+    fn test_at_exact_threshold_uses_gps() {
+        // EKF velocity exactly at threshold (0.1) should fall back to GPS
+        // since condition is > 0.1, not >= 0.1
+        let ekf = Some((0.1, 0.0)); // magnitude = 0.1
+        let gps = Some((1.0, 1.0));
+
+        let (vx, vy, _) = select_best_velocity(ekf, gps);
+
+        // Should use GPS since EKF is not strictly greater than threshold
+        assert_eq!((vx, vy), (1.0, 1.0));
+    }
+
+    #[test]
+    fn test_just_above_threshold_uses_ekf() {
+        // EKF velocity just above threshold should use EKF
+        let ekf = Some((0.11, 0.0)); // magnitude = 0.11 > 0.1
+        let gps = Some((1.0, 1.0));
+
+        let (vx, vy, _) = select_best_velocity(ekf, gps);
+
+        assert_eq!((vx, vy), (0.11, 0.0));
+    }
+}

--- a/release-notes.md
+++ b/release-notes.md
@@ -122,7 +122,7 @@ None reported yet! This is the first release.
 Built with:
 - Rust ESP-IDF framework
 - ESP32-C3 RISC-V chip
-- motorsport-telemetry library
+- sensor-fusion library
 
 ---
 

--- a/sensors/README.md
+++ b/sensors/README.md
@@ -1,6 +1,6 @@
 # Sensor Projects
 
-This directory contains sensor projects built using the **Motorsport Telemetry Framework**.
+This directory contains sensor projects built using the **Sensor Fusion Framework**.
 
 Each subdirectory is a complete, independent sensor application that uses the framework for sensor fusion and coordinate transformations.
 
@@ -57,7 +57,7 @@ edition = "2021"
 
 [dependencies]
 # Core framework
-motorsport-telemetry = { path = "../../framework" }
+sensor-fusion = { path = "../../framework" }
 
 # Sensor drivers (if using existing ones)
 wt901 = { path = "../../drivers/wt901" }
@@ -76,8 +76,8 @@ esp-idf-svc = "0.51"
 ### 4. Implement Your Application
 
 ```rust
-use motorsport_telemetry::ekf::Ekf;
-use motorsport_telemetry::transforms::{body_to_earth, remove_gravity};
+use sensor_fusion::ekf::Ekf;
+use sensor_fusion::transforms::{body_to_earth, remove_gravity};
 
 fn main() {
     // Initialize your hardware

--- a/sensors/blackbox/Cargo.toml
+++ b/sensors/blackbox/Cargo.toml
@@ -6,7 +6,7 @@ edition.workspace = true
 
 [dependencies]
 # Sensor fusion framework (workspace member)
-motorsport-telemetry = { path = "../../framework" }
+sensor-fusion = { path = "../../framework" }
 
 # Sensor drivers (workspace members)
 wt901 = { path = "../../drivers/wt901" }

--- a/sensors/blackbox/src/config.rs
+++ b/sensors/blackbox/src/config.rs
@@ -2,7 +2,7 @@
 
 /// Configuration management for Blackbox telemetry system
 /// Provides defaults and structure for future config.toml loading
-use motorsport_telemetry::ekf::EkfConfig;
+use sensor_fusion::ekf::EkfConfig;
 
 use crate::mode::ModeConfig;
 

--- a/sensors/blackbox/src/main.rs
+++ b/sensors/blackbox/src/main.rs
@@ -20,9 +20,9 @@ use esp_idf_hal::{
 };
 use esp_idf_svc::{eventloop::EspSystemEventLoop, nvs::EspDefaultNvsPartition};
 use log::info;
-use motorsport_telemetry::transforms::{body_to_earth, remove_gravity};
 use mqtt::MqttClient;
 use rgb_led::RgbLed;
+use sensor_fusion::transforms::{body_to_earth, remove_gravity};
 use system::{SensorManager, StateEstimator, StatusManager, TelemetryPublisher};
 use udp_stream::UdpTelemetryStream;
 use websocket_server::{TelemetryServer, TelemetryServerState};
@@ -507,7 +507,7 @@ fn main() {
         // Publish telemetry at configured rate
         if now_ms - last_telemetry_ms >= config.telemetry.interval_ms {
             // Update mode classifier
-            let (vx, vy) = estimator.ekf.velocity();
+            let speed = sensors.get_speed(Some(&estimator.ekf));
             let (ax_corr, ay_corr, _) = sensors.imu_parser.get_accel_corrected();
             let (ax_b, ay_b, _) = remove_gravity(
                 ax_corr,
@@ -529,8 +529,7 @@ fn main() {
                 ay_e,
                 estimator.ekf.yaw(),
                 sensors.imu_parser.data().wz,
-                vx,
-                vy,
+                speed,
             );
 
             // Publish telemetry


### PR DESCRIPTION
## Summary

  Closes #19

  - Moves speed estimation logic from `main.rs` to `SensorManager`
  - Adds `get_velocity()` returning consistent `(vx, vy, speed)` tuple from same source
  - Adds `get_speed()` convenience wrapper
  - Extracts pure `select_best_velocity()` to framework crate with 8 unit tests
  - Refactors mode classifier to take `speed` instead of `(vx, vy)`

  ## Why `get_velocity()` instead of just `get_speed()`?

  The original issue proposed `get_speed()`, but analysis revealed:
  - `TelemetryPublisher` needs `vx`, `vy`, AND `speed` to be **consistent** (from same source)
  - Mixing EKF velocity components with GPS speed would produce incorrect data
  - `get_velocity()` returns a consistent tuple; `get_speed()` is a thin wrapper

  ## Bonus: Crate rename

  Renamed `motorsport-telemetry` → `sensor-fusion` (more accurate name since the algorithms are generic, not motorsport-specific).
