### PR TITLE
Fix local flash to use custom 2.5MB partition table

### DIFF
--- a/sdkconfig.defaults
+++ b/sdkconfig.defaults
@@ -4,7 +4,7 @@ CONFIG_ESP_MAIN_TASK_STACK_SIZE=8192
 CONFIG_ESP_SYSTEM_EVENT_TASK_STACK_SIZE=4096
 CONFIG_ESPTOOLPY_FLASHSIZE_4MB=y
 # Note: Custom partition table disabled - using default partition layout
-# To use custom 2.5 MB app partition locally, uncomment and ensure partitions.csv exists:
+# espflash uses --partition-table flag instead (configured in .cargo/config.toml)
 # CONFIG_PARTITION_TABLE_CUSTOM=y
 # CONFIG_PARTITION_TABLE_CUSTOM_FILENAME="partitions.csv"
 CONFIG_COMPILER_OPTIMIZATION_SIZE=y

--- a/sensors/blackbox/.cargo/config.toml
+++ b/sensors/blackbox/.cargo/config.toml
@@ -3,7 +3,7 @@ target = "riscv32imc-esp-espidf"
 
 [target.riscv32imc-esp-espidf]
 linker = "ldproxy"
-runner = "espflash flash --monitor"
+runner = "espflash flash --monitor --partition-table ../../partitions.csv"
 
 [env]
 ESP_IDF_SYS_ROOT_CRATE = "blackbox"


### PR DESCRIPTION
Summary                                                                                                                                                                                     
                                                                                                                                                                                              
  - Adds --partition-table ../../partitions.csv to the cargo runner config so cargo espflash flash --release --monitor works without manual flags                                             
  - Updates sdkconfig.defaults comment to reflect that espflash handles the partition table via flag, not ESP-IDF config                                                                      
                                                                                                                                                                                              
  Context                                                                                                                                                                                     
                                                                                                                                                                                              
  The firmware binary is ~1.5MB, which exceeds the default ESP32 partition layout (1MB app). The CI workflow already passes --partition-table to espflash save-image (18a0cd5), but the local 
  cargo runner config was never updated to match. This caused cargo espflash flash to fail with image_too_big on every local flash attempt.                                                   
                                                                                                                                                                                              
  Test plan                                                                                                                                                                                   
                                                                                                                                                                                              
  - cargo espflash flash --release --monitor flashes successfully without manual --partition-table flag